### PR TITLE
Fix to show category path in sitemap.xml

### DIFF
--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -21,7 +21,7 @@ SitemapGenerator::Sitemap.create do
     add post_path(post), changefreq: 'weekly', priority: 0.8
   end
 
-  site.categories do |category|
+  site.categories.find_each do |category|
     add category_path(category.slug), changefreq: 'daily', priority: 0.6
   end
 


### PR DESCRIPTION
The links for category aren't shown unless `find_each` :innocent:
