### PR TITLE
Clean description

### DIFF
--- a/app/decorators/post_decorator.rb
+++ b/app/decorators/post_decorator.rb
@@ -1,4 +1,8 @@
 module PostDecorator
+  def to_meta_description
+    plain_text_body.first(140)
+  end
+
   def to_og_params
     {
       locale: 'ja_JP',
@@ -17,5 +21,11 @@ module PostDecorator
       section: category.name,
       published_time: published_at.to_datetime.to_s
     }
+  end
+
+  private
+
+  def plain_text_body
+    @plain_text_body ||= strip_tags(render_markdown(body)).gsub(/[[:space:]]+/, ' ')
   end
 end

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -3,7 +3,7 @@
   - content_for(:canonical_tag) do
     %link{rel: :canonical, href: url_for(all: true, only_path: false)}
 - breadcrumb :post, @post
-- set_meta_tags title: @post.title, description: @post.body, og: @post.to_og_params, article: @post.to_article_params
+- set_meta_tags title: @post.title, description: @post.to_meta_description, og: @post.to_og_params, article: @post.to_article_params
 
 %article
   %h1= @post.title


### PR DESCRIPTION
We must strip :space: because meta-tags won't stlip spaces like nbsp.
