### PR TITLE
Fix timezone problem

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -14,7 +14,7 @@ module NewsService
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
+    config.time_zone = 'Tokyo'
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]

--- a/scripts/sync_wp_posts.rb
+++ b/scripts/sync_wp_posts.rb
@@ -98,11 +98,11 @@ target.find_each.with_index do |wp_post, i|
 
     post.update!(
       title:         wp_post.post_title,
-      published_at:  wp_post.post_date,
+      published_at:  wp_post.post_date_gmt,
       body:          wp_post.post_content,
       category:      category,
       thumbnail_url: wp_post.thumbnail_url,
-      updated_at:    wp_post.post_modified
+      updated_at:    wp_post.post_modified_gmt
     )
   end
 end


### PR DESCRIPTION
- WordPress から取り込む際に参照する日付が WordPress の設定依存になっていたため、 JST を UTC として解釈していた
- time_zone の設定が常に UTC になっていたため、公開日として見えるのが UTC になっていた
