### PR TITLE
Drop original_id

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,6 @@
 class PostsController < ApplicationController
   def show
-    @post = current_site.posts.published.find_by!(original_id: params[:original_id])
+    @post = current_site.posts.published.find_by!(id: params[:id])
 
     @pages =
       if params[:all]

--- a/app/decorators/page_decorator.rb
+++ b/app/decorators/page_decorator.rb
@@ -1,5 +1,0 @@
-module PageDecorator
-  def markdown_body
-    @markdown_body ||= ReverseMarkdown.convert(body).gsub("\r", "\n")
-  end
-end

--- a/app/decorators/post_decorator.rb
+++ b/app/decorators/post_decorator.rb
@@ -9,7 +9,7 @@ module PostDecorator
       type: 'article',
       title: title,
       description: body,
-      url: post_url(original_id, all: true),
+      url: post_url(id, all: true),
       site_name: site.name,
       modified_time: updated_at.to_datetime.to_s,
       image: thumbnail_url

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -6,7 +6,7 @@ class Post < ActiveRecord::Base
   accepts_nested_attributes_for :images, allow_destroy: true
 
   scope :published, -> { where('published_at <= ?', Time.current) }
-  scope :order_by_recently, -> { order(:published_at => :desc, :original_id => :asc) }
+  scope :order_by_recently, -> { order(:published_at => :desc, :id => :asc) }
 
   paginates_per 20
 
@@ -22,15 +22,15 @@ class Post < ActiveRecord::Base
 
   def next_post
     @next_post ||= around_posts_candidates
-      .order(:original_id => :desc)
-      .where('original_id > ?', original_id)
+      .order(:id => :desc)
+      .where('id > ?', id)
       .first
   end
 
   def previous_post
     @previous_post ||= around_posts_candidates
-      .order(:original_id)
-      .where('original_id < ?', original_id)
+      .order(:id)
+      .where('id < ?', id)
       .first
   end
 

--- a/app/views/feed/show.xml.builder
+++ b/app/views/feed/show.xml.builder
@@ -11,8 +11,8 @@ xml.rss('version' => '2.0', 'xmlns:dc' => 'http://purl.org/dc/elements/1.1/') do
         xml.description post.body
         xml.category post.category.name
         xml.pubDate post.published_at.to_s(:rfc822)
-        xml.guid post_url(post.original_id), isPermaLink: true
-        xml.link post_url(post.original_id)
+        xml.guid post_url(post), isPermaLink: true
+        xml.link post_url(post)
       end
     end
   end

--- a/app/views/posts/_summary.html.haml
+++ b/app/views/posts/_summary.html.haml
@@ -1,5 +1,5 @@
 %li.article-summary.article-summary--with-thumbnail
-  = link_to post_url(post.original_id), class: 'article-summary__url' do
+  = link_to post_url(post), class: 'article-summary__url' do
     = image_tag post.thumbnail_url, class: 'article-summary__thumbnail'
     .article-summary__body
       %p.article-summary__title

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -10,7 +10,7 @@
   %p.post__data
     %time.post__data-item.post__data-item--published-at= l @post.published_at.to_date
   .post__body
-    = raw render_markdown(@pages.map(&:markdown_body).join)
+    = raw render_markdown(@pages.map(&:body).join)
 
   - if @pages.respond_to?(:total_pages) && @pages.total_pages > 1
     %nav.pagination

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -19,7 +19,7 @@
   = render partial: 'banner', locals: {position: :press_article_bottom}
 
   %aside
-    = render partial: 'sns_share', locals: {title: @post.title, url: post_url(@post.original_id), twitter_account: current_site.twitter_account, caption: current_site.sns_share_caption}
+    = render partial: 'sns_share', locals: {title: @post.title, url: post_url(@post), twitter_account: current_site.twitter_account, caption: current_site.sns_share_caption}
 
     = render partial: 'short_collection', locals: {posts: @post.related_posts}
 
@@ -27,8 +27,8 @@
       - if @post.next_post.present?
         %li.page-navi
           .page-navi__label 次の記事へ
-          = link_to @post.next_post.title, post_path(@post.next_post.original_id), class: 'page-navi__link'
+          = link_to @post.next_post.title, post_path(@post.next_post), class: 'page-navi__link'
       - if @post.previous_post.present?
         %li.page-navi
           .page-navi__label 前の記事へ
-          = link_to @post.previous_post.title, post_path(@post.previous_post.original_id), class: 'page-navi__link'
+          = link_to @post.previous_post.title, post_path(@post.previous_post), class: 'page-navi__link'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,8 +4,7 @@ Rails.application.routes.draw do
   root 'welcome#index'
 
   concern :site do
-    resources :posts, only: %i(show), param: :original_id, constraints: {original_id: /\d+/}, path: '/'
-    get '/:original_id/:page' => redirect('/%{original_id}?page=%{page}'), constraints: {original_id: /\d+/, page: /\d+/} # To compatible with old URL
+    resources :posts, only: %i(show)
     resources :categories, only: %i(show), path: 'category'
 
     resource :feed, only: %i(show), path: 'feed', controller: 'feed'

--- a/db/migrate/20160115052739_remove_original_id_from_post.rb
+++ b/db/migrate/20160115052739_remove_original_id_from_post.rb
@@ -1,0 +1,7 @@
+class RemoveOriginalIdFromPost < ActiveRecord::Migration
+  def change
+    remove_index :posts, column: [:published_at, :original_id]
+    remove_index :posts, column: [:site_id, :original_id]
+    remove_column :posts, :original_id, :integer
+  end
+end

--- a/db/migrate/20160115054020_add_indexes_to_post.rb
+++ b/db/migrate/20160115054020_add_indexes_to_post.rb
@@ -1,0 +1,6 @@
+class AddIndexesToPost < ActiveRecord::Migration
+  def change
+    add_index :posts, [:published_at, :id]
+    add_index :posts, [:site_id, :id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160115052739) do
+ActiveRecord::Schema.define(version: 20160115054020) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -69,6 +69,8 @@ ActiveRecord::Schema.define(version: 20160115052739) do
     t.string   "thumbnail_url"
   end
 
+  add_index "posts", ["published_at", "id"], name: "index_posts_on_published_at_and_id", using: :btree
+  add_index "posts", ["site_id", "id"], name: "index_posts_on_site_id_and_id", unique: true, using: :btree
   add_index "posts", ["site_id"], name: "index_posts_on_site_id", using: :btree
   add_index "posts", ["updated_at"], name: "index_posts_on_updated_at", using: :btree
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160114063055) do
+ActiveRecord::Schema.define(version: 20160115052739) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -66,12 +66,9 @@ ActiveRecord::Schema.define(version: 20160114063055) do
     t.datetime "published_at"
     t.integer  "category_id"
     t.string   "source_url"
-    t.integer  "original_id"
     t.string   "thumbnail_url"
   end
 
-  add_index "posts", ["published_at", "original_id"], name: "index_posts_on_published_at_and_original_id", using: :btree
-  add_index "posts", ["site_id", "original_id"], name: "index_posts_on_site_id_and_original_id", unique: true, using: :btree
   add_index "posts", ["site_id"], name: "index_posts_on_site_id", using: :btree
   add_index "posts", ["updated_at"], name: "index_posts_on_updated_at", using: :btree
 

--- a/db/seeds/development/posts.seeds.rb
+++ b/db/seeds/development/posts.seeds.rb
@@ -10,7 +10,6 @@ after 'development:sites', 'development:categories' do
     EOS
     published_at: Time.current,
     category: site1.categories.find_by!(slug: 'category1'),
-    original_id: 1
   )
 
   published_at = 3.minutes.from_now
@@ -25,7 +24,6 @@ after 'development:sites', 'development:categories' do
     EOS
     published_at: published_at,
     category: site1.categories.find_by!(slug: 'category2'),
-    original_id: 2
   )
 
   100.times do |i|
@@ -46,7 +44,6 @@ after 'development:sites', 'development:categories' do
       EOS
       published_at: Time.current,
       category: site1.categories.find_by!(slug: 'category1'),
-      original_id: i
     )
   end
 end

--- a/test/integration/post_body_test.rb
+++ b/test/integration/post_body_test.rb
@@ -16,7 +16,7 @@ class PostBodyHeaderTest < ActionDispatch::IntegrationTest
   include PostHelper
 
   setup do
-    create_published_post(
+    @post = create_published_post(
       body: <<~EOS.encode(crlf_newline: true),
         <h1> hi </h1>
         contents
@@ -25,7 +25,7 @@ class PostBodyHeaderTest < ActionDispatch::IntegrationTest
   end
 
   test "body shouldn't have <br>" do
-    visit '/1'
+    visit post_url(@post)
 
     within '.post__body' do
       assert page.has_selector?('h1', text: 'hi')
@@ -38,7 +38,7 @@ class PostBodyNewLineTest < ActionDispatch::IntegrationTest
   include PostHelper
 
   setup do
-    create_published_post(
+    @post = create_published_post(
       body: <<~EOS.encode(crlf_newline: true),
         following line should be breaked:
         hi
@@ -47,7 +47,7 @@ class PostBodyNewLineTest < ActionDispatch::IntegrationTest
   end
 
   test 'body should have <br>' do
-    visit '/1'
+    visit post_url(@post)
 
     within '.post__body' do
       elem = find('p').native
@@ -56,7 +56,7 @@ class PostBodyNewLineTest < ActionDispatch::IntegrationTest
 
       assert_equal 'following line should be breaked:', elem.children[0].text
       assert_equal 'br', elem.children[1].name
-      assert_equal "\n hi", elem.children[2].text
+      assert_equal "\nhi", elem.children[2].text
     end
   end
 end

--- a/test/integration/post_body_test.rb
+++ b/test/integration/post_body_test.rb
@@ -1,12 +1,11 @@
 require 'test_helper'
 
 module PostHelper
-  def create_published_post(body:, original_id:)
+  def create_published_post(body:)
     site = Site.create!(name: 'test', fqdn: 'www.example.com', js_url: '', css_url: '')
     category = site.categories.create!(name: 'category1', slug: 'cate1', order: 1)
     site.posts.create!(
       body:         body,
-      original_id:  original_id,
       published_at: Time.current,
       category:     category
     )
@@ -22,7 +21,6 @@ class PostBodyHeaderTest < ActionDispatch::IntegrationTest
         <h1> hi </h1>
         contents
       EOS
-      original_id: 1
     )
   end
 
@@ -45,7 +43,6 @@ class PostBodyNewLineTest < ActionDispatch::IntegrationTest
         following line should be breaked:
         hi
       EOS
-      original_id: 1
     )
   end
 


### PR DESCRIPTION
- Drop posts.original_id
- Use raw markdown text instead of text processed by ReverseMarkdown
- Fix tests

Close  #172, #177 
