### PR TITLE
Upload thumbnail

### DIFF
--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -54,7 +54,7 @@ class Admin::PostsController < Admin::ApplicationController
       :title,
       :body,
       :category_id,
-      :thumbnail_url,
+      :thumbnail,
       :published_at
     )
   end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -7,6 +7,8 @@ class Post < ActiveRecord::Base
 
   paginates_per 20
 
+  mount_uploader :thumbnail, ImageUploader
+
   def pages
     @pages ||= Page.pages_for(body)
   end

--- a/app/views/admin/posts/_form.html.haml
+++ b/app/views/admin/posts/_form.html.haml
@@ -2,7 +2,10 @@
   = f.text_field :title
   = f.text_area :body
   = f.collection_select :category_id, current_site.categories, :id, :name
-  = f.text_field :thumbnail_url
+  = f.file_field :thumbnail
+  - if @post.thumbnail.present?
+    = f.form_group do
+      = image_tag @post.thumbnail_url, height: 80
   = f.datetime_local_field :published_at
 
   = f.form_group do

--- a/app/views/admin/posts/index.html.haml
+++ b/app/views/admin/posts/index.html.haml
@@ -6,7 +6,7 @@
       %th Title
       %th Body
       %th Category
-      %th Thumbnail url
+      %th Thumbnail
       %th
       %th
       %th
@@ -17,7 +17,7 @@
         %td= post.title
         %td= post.body
         %td= post.category&.name
-        %td= post.thumbnail_url
+        %td= image_tag post.thumbnail_url, height: 80 if post.thumbnail.present?
         %td= link_to 'Show', [:admin, post]
         %td= link_to 'Edit', edit_admin_post_path(post)
         %td= link_to 'Destroy', [:admin, post], method: :delete, data: { confirm: 'Are you sure?' }

--- a/app/views/admin/posts/show.html.haml
+++ b/app/views/admin/posts/show.html.haml
@@ -9,7 +9,7 @@
   = @post.category&.name
 %p
   %b Thumbnail url:
-  = @post.thumbnail_url
+  = image_tag @post.thumbnail_url, height: 80 if @post.thumbnail.present?
 
 = link_to 'Edit', edit_admin_post_path(@post)
 \|

--- a/db/migrate/20160202025140_add_posts_thumbnail.rb
+++ b/db/migrate/20160202025140_add_posts_thumbnail.rb
@@ -1,0 +1,5 @@
+class AddPostsThumbnail < ActiveRecord::Migration
+  def change
+    add_column :posts, :thumbnail, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160128102626) do
+ActiveRecord::Schema.define(version: 20160202025140) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -67,6 +67,7 @@ ActiveRecord::Schema.define(version: 20160128102626) do
     t.integer  "category_id"
     t.string   "source_url"
     t.string   "thumbnail_url"
+    t.string   "thumbnail"
   end
 
   add_index "posts", ["published_at", "id"], name: "index_posts_on_published_at_and_id", using: :btree

--- a/scripts/sync_wp_posts.rb
+++ b/scripts/sync_wp_posts.rb
@@ -97,12 +97,12 @@ target.find_each.with_index do |wp_post, i|
     post = site.posts.find_or_initialize_by(original_id: wp_post.id)
 
     post.update!(
-      title:         wp_post.post_title,
-      published_at:  wp_post.post_date_gmt,
-      body:          wp_post.post_content,
-      category:      category,
-      thumbnail_url: wp_post.thumbnail_url,
-      updated_at:    wp_post.post_modified_gmt
+      title:                wp_post.post_title,
+      published_at:         wp_post.post_date_gmt,
+      body:                 wp_post.post_content,
+      category:             category,
+      remote_thumbnail_url: wp_post.thumbnail_url,
+      updated_at:           wp_post.post_modified_gmt
     )
   end
 end


### PR DESCRIPTION
サムネイル画像を管理画面から設定できるようにしました。
`posts.thumbnail_url` を消さないといけないんですが、 press ブランチでのデータ移行が終わったあとにやっつけたいです。
