### PR TITLE
Prevent 500 error when template is missing

### DIFF
--- a/app/handlers/exceptions_app.rb
+++ b/app/handlers/exceptions_app.rb
@@ -5,6 +5,9 @@ class ExceptionsApp < Rambulance::ExceptionsApp
   helper CurrentResouceHelper
 
   def not_found
+    respond_to do |format|
+      format.any { render(formats: :html, content_type: 'text/html', layout: 'error') }
+    end
   end
 
   def internal_server_error

--- a/test/integration/request_format_test.rb
+++ b/test/integration/request_format_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+
+class MissingTemplateTest < ActionDispatch::IntegrationTest
+  setup do
+    @site = Site.create!(name: 'daimon-news', fqdn: 'www.example.com', js_url: '', css_url: '')
+
+    Rails.application.env_config['action_dispatch.show_detailed_exceptions'] = false
+    Rails.application.env_config['action_dispatch.show_exceptions'] = true
+  end
+
+  teardown do
+    Rails.application.env_config['action_dispatch.show_detailed_exceptions'] = true
+    Rails.application.env_config['action_dispatch.show_exceptions'] = false
+  end
+
+  sub_test_case "not found" do
+    test "no extension" do
+      visit '/foo'
+      assert_equal 404, page.status_code
+    end
+
+    test "html" do
+      visit '/foo.html'
+      assert_equal 404, page.status_code
+    end
+
+    test "json" do
+      visit '/foo.json'
+      assert_equal 404, page.status_code
+    end
+  end
+end


### PR DESCRIPTION
現状、URL直打ちでMissingTemplateエラーが発生する可能性がありますが、
それがサーバーエラーになってしまい、不必要なアラートが上がります。
#203 にもメモしていましたが、改めて対応方針を整理しました。
- レコードが存在するURLは正しいフォーマットで表示する
  （現状のmasterで未対応のフォーマット（`.xxx`など）を指定したときと同じ挙動）
  - `/1.json` -> `/1.html`を表示
  - `/feed.html` -> `/feed.xml`を表示
- レコードが存在しないURLは404エラーを表示する
  - `/hoge.json`など

できればRambulanceの設定などで汎用的に対応したかったのですが、今は各コントローラーで
正しいフォーマットを指定して`request.format`を書き換える実装になっています。

close #203
