### PR TITLE
Add preview link to "editor/posts#show"

### DIFF
--- a/app/views/editor/posts/show.html.haml
+++ b/app/views/editor/posts/show.html.haml
@@ -15,6 +15,8 @@
   %b Thumbnail url:
   = image_tag @post.thumbnail_url, height: 80 if @post.thumbnail.present?
 
+= link_to 'Preview', preview_editor_post_url, target: '_blank'
+\|
 = link_to 'Edit', edit_editor_post_url
 \|
 = link_to 'Back', editor_posts_url


### PR DESCRIPTION
記事更新後は `editor/posts#show` に遷移するので、すぐにプレビューが見れるように
`editor/posts#show` にも `editor/posts#preview` へのリンクを追加しました。
（今は `editor/posts#index` にしかプレビューのリンクがない）

ref: #229
