### PR TITLE
Use `Post#update` instead of `Post#update_columns`

### DIFF
--- a/app/controllers/editor/posts_controller.rb
+++ b/app/controllers/editor/posts_controller.rb
@@ -28,7 +28,7 @@ class Editor::PostsController < Editor::ApplicationController
   def update
     @post = posts.find_by!(public_id: params[:id])
 
-    if @post.update_columns(post_params)
+    if @post.update(post_params)
       redirect_to [:editor, @post], notice: '記事が更新されました。'
     else
       render :edit


### PR DESCRIPTION
This was a workaround to keep previous `Post#updated_at`.
However this breaks file uploading.

Currentry we use `Post#original_updated_at` for original post,
and no longer `update_columns` is required.
