### PR TITLE
Revert "Merge pull request #256 from bm-sms/add-missing-canonical"

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -3,8 +3,7 @@ class CategoriesController < ApplicationController
 
   def show
     @category = current_site.categories.find_by!(slug: params[:id])
-    @posts = current_site.posts.where(category: @category).published.order_by_recently
-    @posts = @posts.page(params[:page]) unless params[:all]
+    @posts = current_site.posts.where(category: @category).published.order_by_recently.page(params[:page])
   end
 
   private

--- a/app/views/categories/show.html.haml
+++ b/app/views/categories/show.html.haml
@@ -1,8 +1,5 @@
-- if @posts.respond_to?(:total_pages)
-  - content_for(:rel_next_prev_link_tags) { rel_next_prev_link_tags(@posts) }
-- content_for(:canonical_tag) do
-  %link{rel: :canonical, href: url_for(all: true, only_path: false)}
-- if @posts.respond_to?(:total_pages) && @posts.current_page > 1
+- content_for(:rel_next_prev_link_tags) { rel_next_prev_link_tags(@posts) }
+- if @posts.current_page > 1
   - breadcrumb :page_num, @posts.current_page, @category
 - else
   - breadcrumb :category, @category
@@ -18,7 +15,7 @@
       = render partial: 'posts/summary', locals: {post: post}
     = render partial: 'native_ad', locals: {position: :press_articles_bottom}
 
-  - if @posts.respond_to?(:total_pages) && @posts.total_pages > 1
+  - if @posts.total_pages > 1
     %nav.pagination
       = paginate @posts
       %p.pagination__entries= page_entries_info @posts

--- a/test/integration/canonical_test.rb
+++ b/test/integration/canonical_test.rb
@@ -22,23 +22,4 @@ class CanonicalTest < ActionDispatch::IntegrationTest
 
     assert_equal "http://#{@post.site.fqdn}/#{@post.public_id}?all=true", find('link[rel=canonical]', visible: false)[:href]
   end
-
-  sub_test_case 'category page' do
-    setup do
-      @category = create(:category, site: @post.site)
-    end
-
-    data({
-      "no parameter"            => "",
-      "pagination"              => "?page=2",
-      "unexpected"              => "?aaa=bbb&c_c=d.d",
-      "all=true"                => "?all=true",
-      "all=true and unexpected" => "?all=true&aaa=123",
-    })
-    def test_normalize(data)
-      visit "/category/#{@category.slug}#{data}"
-      assert_equal "http://#{@post.site.fqdn}/category/#{@category.slug}?all=true",
-                   find('link[rel=canonical]', visible: false)[:href]
-    end
-  end
 end


### PR DESCRIPTION
`all=true` for category page is unexpected behavior.

This reverts commit 42d45c79856e6b95fc4a1330d62d085e866dfd1b, reversing
changes made to 4a264d0a9825d001d8c91f0fd3b96e2f3c563fcf.
