### PR TITLE
Sort posts on editor/posts#index

### DIFF
--- a/app/controllers/editor/posts_controller.rb
+++ b/app/controllers/editor/posts_controller.rb
@@ -1,6 +1,6 @@
 class Editor::PostsController < Editor::ApplicationController
   def index
-    @posts = posts.preload(:category)
+    @posts = posts.preload(:category).order(:public_id => :desc)
   end
 
   def show


### PR DESCRIPTION
記事を更新する度に並び順が入れ替わって苦しかったので、順番を指定しました。
