### PR TITLE
関連記事検索

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 !/log/.keep
 /tmp
 /public/uploads
+/groonga/data/

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,8 @@ end
 
 gem 'mysql2', require: false
 
+gem 'rroonga'
+
 group :development, :test do
   gem 'pry-byebug'
   gem 'factory_girl'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,8 @@ GEM
     airbrake (5.0.5)
       airbrake-ruby (~> 1.0)
     airbrake-ruby (1.0.4)
+    archive-zip (0.8.0)
+      io-like (~> 0.3.0)
     arel (6.0.3)
     autoprefixer-rails (6.3.3.1)
       execjs
@@ -213,8 +215,14 @@ GEM
     git-version-bump (0.15.1)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
+    gqtp (1.0.6)
     gretel (3.0.8)
       rails (>= 3.2.0)
+    groonga-client (0.1.9)
+      gqtp (>= 1.0.4)
+      groonga-command (>= 1.0.8)
+    groonga-command (1.1.6)
+      json
     haml (4.0.7)
       tilt
     haml-rails (0.9.0)
@@ -230,6 +238,7 @@ GEM
       ruby_parser (~> 3.5)
     i18n (0.7.0)
     inflecto (0.0.2)
+    io-like (0.3.0)
     ipaddress (0.8.3)
     jquery-rails (4.1.0)
       rails-dom-testing (~> 1.0)
@@ -262,6 +271,7 @@ GEM
     orm_adapter (0.5.0)
     pandoc-ruby (1.0.0)
     pg (0.18.4)
+    pkg-config (1.1.7)
     poltergeist (1.9.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -341,6 +351,11 @@ GEM
     reverse_markdown (1.0.1)
       nokogiri
     rr (1.1.2)
+    rroonga (5.1.1)
+      archive-zip
+      groonga-client (>= 0.0.3)
+      json
+      pkg-config
     ruby_parser (3.8.1)
       sexp_processor (~> 4.1)
     sass (3.4.21)
@@ -458,6 +473,7 @@ DEPENDENCIES
   rambulance
   redcarpet
   reverse_markdown
+  rroonga
   sass-rails
   seedbank
   select2-rails

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec puma -C config/puma.rb
+web: bundle exec ruby groonga/init.rb && bundle exec puma -C config/puma.rb

--- a/app.json
+++ b/app.json
@@ -30,6 +30,9 @@
       "url": "https://github.com/ddollar/heroku-buildpack-apt"
     },
     {
+      "url": "https://codon-buildpacks.s3.amazonaws.com/buildpacks/groonga/groonga.tgz"
+    },
+    {
       "url": "https://github.com/heroku/heroku-buildpack-ruby"
     }
   ],

--- a/app/groonga/post_indexer.rb
+++ b/app/groonga/post_indexer.rb
@@ -9,7 +9,11 @@ class PostIndexer
   def add(post)
     return if @posts.nil?
     site = @sites.add(post.site_id)
-    category = @categories.add(post.category_id)
+    if post.category
+      category = @categories.add(post.category_id)
+    else
+      category = nil
+    end
     participants = post.credits.map do |credit|
       @participants.add(credit.participant_id)
     end

--- a/app/groonga/post_indexer.rb
+++ b/app/groonga/post_indexer.rb
@@ -1,0 +1,37 @@
+class PostIndexer
+  def initialize
+    @sites = Groonga['Sites']
+    @categories = Groonga['Categories']
+    @authors = Groonga['Authors']
+    @posts = Groonga['Posts']
+  end
+
+  def add(post)
+    return if @posts.nil?
+    site = @sites.add(post.site_id)
+    category = @categories.add(post.category_id)
+    if post.author_id
+      author = @authors.add(post.author_id)
+    else
+      author = nil
+    end
+    @posts.add(post.id,
+               title: post.title,
+               content: extract_content(post),
+               published_at: post.published_at,
+               site: site,
+               category: category,
+               author: author)
+  end
+
+  def remove(post)
+    return if @posts.nil?
+    @posts[post.id].delete
+  end
+
+  private
+
+  def extract_content(post)
+    post.body
+  end
+end

--- a/app/groonga/post_indexer.rb
+++ b/app/groonga/post_indexer.rb
@@ -2,7 +2,7 @@ class PostIndexer
   def initialize
     @sites = Groonga['Sites']
     @categories = Groonga['Categories']
-    @authors = Groonga['Authors']
+    @participants = Groonga['Participants']
     @posts = Groonga['Posts']
   end
 
@@ -10,10 +10,8 @@ class PostIndexer
     return if @posts.nil?
     site = @sites.add(post.site_id)
     category = @categories.add(post.category_id)
-    if post.author_id
-      author = @authors.add(post.author_id)
-    else
-      author = nil
+    participants = post.credits.map do |credit|
+      @participants.add(credit.participant_id)
     end
     @posts.add(post.id,
                title: post.title,
@@ -21,7 +19,7 @@ class PostIndexer
                published_at: post.published_at,
                site: site,
                category: category,
-               author: author)
+               participants: participants)
   end
 
   def remove(post)

--- a/app/groonga/post_searcher.rb
+++ b/app/groonga/post_searcher.rb
@@ -1,0 +1,25 @@
+class PostSearcher
+  def initialize
+    @posts = Groonga['Posts']
+  end
+
+  def related_post_ids(post, limit: 5)
+    related_posts = @posts.select do |record|
+      conditions = (record.index('Words.Posts_title').similar_search(post.title))
+      conditions |= (record.index('Words.Posts_content').similar_search(post.body))
+      if post.author
+        conditions |= (record.author._key == post.author.id)
+      end
+      if post.category
+        conditions |= (record.category._key == post.category.id)
+      end
+      conditions &
+        (record.published_at <= Time.now) &
+        (record.site._key == post.site_id) &
+        (record._key != post.id)
+    end
+    related_posts.sort([["_score", :desc]], limit: limit).map do |related_post|
+      related_post._key
+    end
+  end
+end

--- a/app/groonga/post_searcher.rb
+++ b/app/groonga/post_searcher.rb
@@ -8,7 +8,7 @@ class PostSearcher
       conditions = (record.index('Words.Posts_title').similar_search(post.title))
       conditions |= (record.index('Words.Posts_content').similar_search(post.body))
       post.credits.each do |credit|
-        conditions |= (record.participant._key =~ credit.participant_id)
+        conditions |= (record.participants._key =~ credit.participant_id)
       end
       if post.category
         conditions |= (record.category._key == post.category.id)

--- a/app/groonga/post_searcher.rb
+++ b/app/groonga/post_searcher.rb
@@ -7,8 +7,8 @@ class PostSearcher
     related_posts = @posts.select do |record|
       conditions = (record.index('Words.Posts_title').similar_search(post.title))
       conditions |= (record.index('Words.Posts_content').similar_search(post.body))
-      if post.author
-        conditions |= (record.author._key == post.author.id)
+      post.credits.each do |credit|
+        conditions |= (record.participant._key =~ credit.participant_id)
       end
       if post.category
         conditions |= (record.category._key == post.category.id)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -37,9 +37,9 @@ class Post < ActiveRecord::Base
   end
 
   def related_posts
-    maximum_id = Post.published.maximum(:id)
-
-    Post.published.where(category: category).order("(id - #{id} + #{maximum_id} - 1) % #{maximum_id}").limit(9) # XXX 同じカテゴリの中から適当に返している
+    searcher = PostSearcher.new
+    ids = searcher.related_post_ids(self)
+    Post.published.where(id: ids)
   end
 
   def next_post

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -13,6 +13,16 @@ class Post < ActiveRecord::Base
 
   before_save :assign_public_id
 
+  after_save do |post|
+    indexer = PostIndexer.new
+    indexer.add(post)
+  end
+
+  after_destroy do |post|
+    indexer = PostIndexer.new
+    indexer.remove(post)
+  end
+
   scope :published, -> { where('published_at <= ?', Time.current) }
   scope :order_by_recently, -> { order(:published_at => :desc, :id => :asc) }
 

--- a/bin/setup
+++ b/bin/setup
@@ -20,6 +20,9 @@ Dir.chdir APP_ROOT do
   puts "\n== Preparing database =="
   system "bin/rake db:setup"
 
+  puts "\n== Preparing Groonga database =="
+  system "ruby groonga/init.rb"
+
   puts "\n== Removing old logs and tempfiles =="
   system "rm -f log/*"
   system "rm -rf tmp/cache"

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,6 @@
 machine:
   pre:
     - sudo curl --output /usr/local/bin/phantomjs https://s3.amazonaws.com/circle-downloads/phantomjs-2.1.1
+database:
+  post:
+    - ruby groonga/init.rb

--- a/config/initializers/groonga.rb
+++ b/config/initializers/groonga.rb
@@ -1,0 +1,10 @@
+require 'fileutils'
+require 'groonga'
+
+database_path = ENV['GROONGA_DATABASE_PATH'] || 'groonga/data/db'
+if File.exist?(database_path)
+  Groonga::Database.open(database_path)
+else
+  FileUtils.mkdir_p(File.dirname(database_path))
+  Groonga::Database.create(path: database_path)
+end

--- a/groonga/init.rb
+++ b/groonga/init.rb
@@ -1,0 +1,65 @@
+require_relative '../config/environment'
+
+Groonga::Schema.define do |schema|
+  schema.create_table('Sites',
+                      type: :hash,
+                      key_type: :uint32) do |table|
+    table.short_text 'name'
+  end
+
+  schema.create_table('Categories',
+                      type: :hash,
+                      key_type: :uint32) do |table|
+    table.short_text 'name'
+  end
+
+  schema.create_table('Authors',
+                      type: :hash,
+                      key_type: :uint32) do |table|
+    table.short_text 'name'
+  end
+
+  schema.create_table('Posts',
+                      type: :hash,
+                      key_type: :uint32) do |table|
+    table.short_text 'title'
+    table.text 'content'
+    table.time 'published_at'
+    table.reference 'site', 'Sites'
+    table.reference 'category', 'Categories'
+    table.reference 'author', 'Authors'
+  end
+end
+
+if Post.table_exists?
+  indexer = PostIndexer.new
+  Post.find_each do |post|
+    indexer.add(post)
+  end
+end
+
+Groonga::Schema.define do |schema|
+  schema.create_table('Words',
+                      type: :patricia_trie,
+                      key_type: :short_text,
+                      normalizer: 'NormalizerAuto',
+                      default_tokenizer: 'TokenMecab') do |table|
+    table.index 'Posts.title'
+    table.index 'Posts.content'
+  end
+
+  schema.create_table('Terms',
+                      type: :patricia_trie,
+                      key_type: :short_text,
+                      normalizer: 'NormalizerAuto',
+                      default_tokenizer: 'TokenBigram') do |table|
+    table.index 'Posts.title'
+    table.index 'Posts.content'
+  end
+
+  schema.create_table('Times',
+                      type: :patricia_trie,
+                      key_type: :time) do |table|
+    table.index 'Posts.published_at'
+  end
+end

--- a/groonga/init.rb
+++ b/groonga/init.rb
@@ -13,7 +13,7 @@ Groonga::Schema.define do |schema|
     table.short_text 'name'
   end
 
-  schema.create_table('Authors',
+  schema.create_table('Participants',
                       type: :hash,
                       key_type: :uint32) do |table|
     table.short_text 'name'
@@ -27,7 +27,7 @@ Groonga::Schema.define do |schema|
     table.time 'published_at'
     table.reference 'site', 'Sites'
     table.reference 'category', 'Categories'
-    table.reference 'author', 'Authors'
+    table.reference 'participants', 'Participants', type: :vector
   end
 end
 


### PR DESCRIPTION
#185 （検索）の実装の一部です。 #272 でforce pushしたらreview appがうまく作れなくなってしまったので新しいpull requestにしてしまいました。すみません。。。

Groongaの類似文書検索機能を使って関連記事検索を実現しました。
#185 の一貫です。目的も同じで「サイト内の周回を促すこと」です。現在表示中の記事と似たような内容の記事があるほど続けて他の記事も見やすくなり（表示中の記事に関心があるなら似たような内容の記事にも関心がある可能性が高い理論）、結果としてサイト内の周回に結び付く、という考えです。

一から環境を作る場合はこれまでどおり`bin/setup`を実行することで動くようになります。

すでにセットアップ済みの環境で使えるようにするには以下を実行することで動くようになります。

``` text
bundle install
bundle exec ruby groonga/init.rb
```
