### PR TITLE
Fix to create post with credits

### DIFF
--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -3,7 +3,6 @@ class Credit < ActiveRecord::Base
   belongs_to :participant
   belongs_to :role, foreign_key: :credit_role_id, class_name: 'CreditRole'
 
-  validates :post_id, presence: true
   validates :participant_id, presence: true
   validates :credit_role_id, presence: true
 end


### PR DESCRIPTION
記事作成時に、関連情報を一緒に登録すると `Credit` の validation に引っかかっていたのを修正しました。
