### PR TITLE
Redirect to /admin/sites/%{id} when create a site

### DIFF
--- a/app/controllers/admin/sites_controller.rb
+++ b/app/controllers/admin/sites_controller.rb
@@ -20,7 +20,7 @@ class Admin::SitesController < Admin::ApplicationController
         @site.memberships.create!(user: current_user)
       end
 
-      redirect_to root_url(host: @site.fqdn)
+      redirect_to [:admin, @site], notice: 'サイトが作成されました。'
     else
       render :new
     end

--- a/test/integration/admin_test.rb
+++ b/test/integration/admin_test.rb
@@ -19,7 +19,7 @@ class AdminTest < ActionDispatch::IntegrationTest
 
     click_on '登録する'
 
-    assert_equal 'http://daimon.lvh.me/', current_url
+    assert_equal '/admin/sites/2', current_path
 
     visit '/admin'
 


### PR DESCRIPTION
Fix #286
