### PR TITLE
Keep search keywords in textbox

### DIFF
--- a/app/views/search/_form.html.haml
+++ b/app/views/search/_form.html.haml
@@ -1,3 +1,3 @@
 = form_tag search_path, method: :get do
-  = search_field_tag 'query[keywords]'
+  = search_field_tag 'query[keywords]', @query&.keywords
   = submit_tag '検索'

--- a/test/integration/search_test.rb
+++ b/test/integration/search_test.rb
@@ -33,6 +33,10 @@ class SearchTest < ActionDispatch::IntegrationTest
         assert find_link('the post of the current site')
       end
     end
+
+    within('aside') do
+      assert_equal 'contents', find('#query_keywords').value
+    end
   end
 
   test 'unpublished posts should not be shown' do


### PR DESCRIPTION
検索後に、検索クエリが検索欄に残るようにしました。

ref: #185 
