### PR TITLE
Fix drilldown label

### DIFF
--- a/app/views/search/search.html.haml
+++ b/app/views/search/search.html.haml
@@ -9,7 +9,8 @@
       = link_to @query.params(remove: [:participant_id]) do
         %i.fa.fa-remove
     - else
-      絞り込み候補：
+      - unless @result_set.participants.empty?
+        絞り込み候補：
       - @result_set.participants.each do |participant|
         %span
           = link_to participant.name, @query.params(add: {participant_id: participant._key})

--- a/app/views/search/search.html.haml
+++ b/app/views/search/search.html.haml
@@ -3,12 +3,13 @@
     %p 「#{@query.keywords}」を含む記事は見つかりませんでした。
 - else
   %div
-    絞り込み：
     - if @query.participant_id.present?
+      絞り込み中：
       = Participant.find(@query.participant_id).name
       = link_to @query.params(remove: [:participant_id]) do
         %i.fa.fa-remove
     - else
+      絞り込み候補：
       - @result_set.participants.each do |participant|
         %span
           = link_to participant.name, @query.params(add: {participant_id: participant._key})

--- a/app/views/search/search.html.haml
+++ b/app/views/search/search.html.haml
@@ -2,17 +2,17 @@
   %div
     %p 「#{@query.keywords}」を含む記事は見つかりませんでした。
 - else
-  %div
+  %div.drilldown-participant
     - if @query.participant_id.present?
-      絞り込み中：
+      .drilldown-participant-label 絞り込み中：
       = Participant.find(@query.participant_id).name
       = link_to @query.params(remove: [:participant_id]) do
         %i.fa.fa-remove
     - else
       - unless @result_set.participants.empty?
-        絞り込み候補：
+        .drilldown-participant-label 絞り込み候補：
       - @result_set.participants.each do |participant|
-        %span
+        %span.drilldown-participant-link
           = link_to participant.name, @query.params(add: {participant_id: participant._key})
           = "(#{participant.n_sub_records})"
 

--- a/app/views/search/search.html.haml
+++ b/app/views/search/search.html.haml
@@ -8,9 +8,8 @@
       = Participant.find(@query.participant_id).name
       = link_to @query.params(remove: [:participant_id]) do
         %i.fa.fa-remove
-    - else
-      - unless @result_set.participants.empty?
-        %span.drilldown-participant-label 絞り込み候補：
+    - elsif @result_set.participants.present?
+      %span.drilldown-participant-label 絞り込み候補：
       - @result_set.participants.each do |participant|
         %span.drilldown-participant-link
           = link_to participant.name, @query.params(add: {participant_id: participant._key})

--- a/app/views/search/search.html.haml
+++ b/app/views/search/search.html.haml
@@ -4,14 +4,14 @@
 - else
   .drilldown-participant
     - if @query.participant_id.present?
-      %span.drilldown-participant-label 絞り込み中：
+      %span.drilldown-participant__label 絞り込み中：
       = Participant.find(@query.participant_id).name
       = link_to @query.params(remove: [:participant_id]) do
         %i.fa.fa-remove
     - elsif @result_set.participants.present?
-      %span.drilldown-participant-label 絞り込み候補：
+      %span.drilldown-participant__label 絞り込み候補：
       - @result_set.participants.each do |participant|
-        %span.drilldown-participant-link
+        %span.drilldown-participant__link
           = link_to participant.name, @query.params(add: {participant_id: participant._key})
           = "(#{participant.n_sub_records})"
 

--- a/app/views/search/search.html.haml
+++ b/app/views/search/search.html.haml
@@ -2,7 +2,7 @@
   %div
     %p 「#{@query.keywords}」を含む記事は見つかりませんでした。
 - else
-  %div.drilldown-participant
+  .drilldown-participant
     - if @query.participant_id.present?
       .drilldown-participant-label 絞り込み中：
       = Participant.find(@query.participant_id).name

--- a/app/views/search/search.html.haml
+++ b/app/views/search/search.html.haml
@@ -4,13 +4,13 @@
 - else
   .drilldown-participant
     - if @query.participant_id.present?
-      .drilldown-participant-label 絞り込み中：
+      %span.drilldown-participant-label 絞り込み中：
       = Participant.find(@query.participant_id).name
       = link_to @query.params(remove: [:participant_id]) do
         %i.fa.fa-remove
     - else
       - unless @result_set.participants.empty?
-        .drilldown-participant-label 絞り込み候補：
+        %span.drilldown-participant-label 絞り込み候補：
       - @result_set.participants.each do |participant|
         %span.drilldown-participant-link
           = link_to participant.name, @query.params(add: {participant_id: participant._key})

--- a/test/integration/search_test.rb
+++ b/test/integration/search_test.rb
@@ -84,8 +84,8 @@ class SearchTest < ActionDispatch::IntegrationTest
     click_on '検索'
 
     within('main div.drilldown-participant') do
-      assert_equal '絞り込み候補：', find('.drilldown-participant-label').text
-      assert has_css?('.drilldown-participant-link')
+      assert_equal '絞り込み候補：', find('.drilldown-participant__label').text
+      assert has_css?('.drilldown-participant__link')
     end
   end
 
@@ -101,8 +101,8 @@ class SearchTest < ActionDispatch::IntegrationTest
     click_on '検索'
 
     within('main div.drilldown-participant') do
-      assert_false has_css?('.drilldown-participant-label')
-      assert_false has_css?('.drilldown-participant-link')
+      assert_false has_css?('.drilldown-participant__label')
+      assert_false has_css?('.drilldown-participant__link')
     end
   end
 

--- a/test/integration/search_test.rb
+++ b/test/integration/search_test.rb
@@ -71,10 +71,45 @@ class SearchTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'drilldown candidates must be shown if credits exist' do
+    create_post(:with_credit,
+                site: @current_site,
+                title: 'the post of the current site',
+                body: 'contents...')
+
+    visit '/'
+
+    fill_in 'query[keywords]', with: 'contents'
+
+    click_on '検索'
+
+    within('main div.drilldown-participant') do
+      assert_equal '絞り込み候補：', find('.drilldown-participant-label').text
+      assert has_css?('.drilldown-participant-link')
+    end
+  end
+
+  test 'drilldown candidates must not be shown if credits do not exist' do
+    create_post(site: @current_site,
+                title: 'the post of the current site',
+                body: 'contents...')
+
+    visit '/'
+
+    fill_in 'query[keywords]', with: 'contents'
+
+    click_on '検索'
+
+    within('main div.drilldown-participant') do
+      assert_false has_css?('.drilldown-participant-label')
+      assert_false has_css?('.drilldown-participant-link')
+    end
+  end
+
   private
 
-  def create_post(attributes)
-    post = create(:post, attributes)
+  def create_post(*attributes)
+    post = create(:post, :whatever, *attributes)
     @indexer.add(post)
     post
   end


### PR DESCRIPTION
検索結果の関係者絞り込みのラベルを修正しました。
- 絞りこみ候補がない場合はラベルを非表示にした
- 絞り込み中なのかどうかわかるようにした

ref: #185
