### PR TITLE
Fix Groonga::SyntaxError for operators

### DIFF
--- a/app/groonga/post_searcher.rb
+++ b/app/groonga/post_searcher.rb
@@ -43,10 +43,14 @@ class PostSearcher
       conditions << (record.site._key == query.site_id)
 
       if query.keywords.present?
-        full_text_search = record.match(query.keywords) do |target|
+        match_target = record.match_target do |target|
           (target.index('Terms.Posts_title') * 10) |
             target.index('Terms.Posts_content')
         end
+        keywords = query.keywords.split
+        full_text_search = keywords.map {|keyword|
+          match_target =~ keyword
+        }.inject(&:&)
         full_text_search |= (record.participants.name =~ query.keywords)
         full_text_search |= (record.participants.description =~ query.keywords)
         conditions << full_text_search

--- a/test/integration/search_test.rb
+++ b/test/integration/search_test.rb
@@ -147,8 +147,6 @@ class SearchTest < ActionDispatch::IntegrationTest
          "unmatch1 -unmatch2" => "unmatch1 -unmatch2",
          "unmatch1 - unmatch2" => "unmatch1 - unmatch2")
     test 'markdown characters should not be matched' do |data|
-      pend "Groonga::SyntaxError: syntax error: Syntax error:" if /^-/ =~ data
-
       visit '/'
 
       fill_in 'query[keywords]', with: data
@@ -157,6 +155,38 @@ class SearchTest < ActionDispatch::IntegrationTest
 
       within('main') do
         assert_equal "「#{data}」を含む記事は見つかりませんでした。", find('.message').text
+      end
+    end
+  end
+
+  sub_test_case 'operator' do
+    setup do
+      create_post(site: @current_site,
+                  title: 'operators',
+                  body: <<~BODY)
+      # operators
+
+      `+ - -a ~ ( ) < >`
+      BODY
+    end
+
+    data("+" => "+",
+         "-" => "-",
+         "-a" => "-a",
+         "~" => "~",
+         "(" => "(",
+         ")" => ")",
+         "<" => "<",
+         ">" => ">")
+    test 'operators should be as-is' do |data|
+      visit '/'
+
+      fill_in 'query[keywords]', with: data
+
+      click_on '検索'
+
+      within('main') do
+        assert_equal "「#{data}」を含む記事は1件見つかりました。", find('.message').text
       end
     end
   end


### PR DESCRIPTION
`-`単体で検索したときなどに500エラーになる問題の対応。

Close #371 

~~https://github.com/bm-sms/daimon-news-multi-tenant/issues/371#issuecomment-197719924 で指摘を受けた以下の問題も修正しています。~~

~~スペース区切りで複数キーワードを指定した場合、記事と関係者名と関係者説明をそれぞれ別々にAND検索してしまっているため、それぞれに複数キーワードがすべて含まれていないとヒットしなくなっていました。~~

~~例としては、「title author」で検索したとき、関係者名単体で「title」と「author」が含まれていないとヒットしない状況でした。（本来は、記事に「title」が含まれていれば、関係者名に「title」が含まれなくてもヒットするのが期待される）~~

↑は #392 に分離しました。
