### PR TITLE
Remove trailing blank lines

### DIFF
--- a/db/seeds/development/fixed_pages.seeds.rb
+++ b/db/seeds/development/fixed_pages.seeds.rb
@@ -26,4 +26,3 @@ after "development:sites" do
     EOS
   )
 end
-

--- a/test/integration/wip_site_test.rb
+++ b/test/integration/wip_site_test.rb
@@ -51,4 +51,3 @@ class WipSiteTest < ActionDispatch::IntegrationTest
     end
   end
 end
-


### PR DESCRIPTION
```
bundle exec rubocop -a --only Style/TrailingBlankLines
```
