### PR TITLE
Remove data transfer columns

### DIFF
--- a/db/migrate/20160407023218_remove_data_transfer_columns.rb
+++ b/db/migrate/20160407023218_remove_data_transfer_columns.rb
@@ -1,0 +1,9 @@
+class RemoveDataTransferColumns < ActiveRecord::Migration
+  def change
+    remove_column :posts, :original_source, :text
+    remove_column :posts, :original_html, :text
+    remove_column :posts, :stripped_html, :text
+    remove_column :posts, :replaced_html, :text
+    remove_column :posts, :source_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160329021637) do
+ActiveRecord::Schema.define(version: 20160407023218) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -109,15 +109,10 @@ ActiveRecord::Schema.define(version: 20160329021637) do
     t.datetime "updated_at",          null: false
     t.datetime "published_at"
     t.integer  "category_id",         null: false
-    t.string   "source_url"
     t.string   "thumbnail",           null: false
     t.integer  "author_id"
-    t.text     "original_source"
     t.datetime "original_updated_at"
     t.integer  "public_id",           null: false
-    t.text     "original_html"
-    t.text     "stripped_html"
-    t.text     "replaced_html"
   end
 
   add_index "posts", ["published_at", "id"], name: "index_posts_on_published_at_and_id", using: :btree


### PR DESCRIPTION
We cannot rollback this migration, because this migration delets
existing data in those columns.

We must create backup before deploy this PR.
