### PR TITLE
move_google_tag_manger_snipet

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -3,8 +3,9 @@
   = render 'application/head'
 
   %body(data-layer='top'){ class: "#{['root-container', @class_page_name, @class_category_id].compact.join(' ')}" }
-    %div.overlay
+    - # <body> と google tag manager の間には別のタグを入れないこと
     = google_tag_manager(current_site.gtm_id)
+    %div.overlay
     = render 'application/content_header'
 
     = content_for(:notification)

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,6 +4,7 @@
 
   %body(data-layer='top'){ class: "#{['root-container', @class_page_name, @class_category_id].compact.join(' ')}" }
     - # <body> と google tag manager の間には別のタグを入れないこと
+    - # <body> タグと GTMのスニペットの間に別のタグが挟まれていると Search Console の所有者確認でエラーになるため
     = google_tag_manager(current_site.gtm_id)
     %div.overlay
     = render 'application/content_header'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -3,8 +3,7 @@
   = render 'application/head'
 
   %body(data-layer='top'){ class: "#{['root-container', @class_page_name, @class_category_id].compact.join(' ')}" }
-    - # <body> と google tag manager の間には別のタグを入れないこと
-    - # <body> タグと GTMのスニペットの間に別のタグが挟まれていると Search Console の所有者確認でエラーになるため
+    - # Do not insert any other tag between `<body>` and GTM snippet. See https://developers.google.com/tag-manager/quickstart
     = google_tag_manager(current_site.gtm_id)
     %div.overlay
     = render 'application/content_header'


### PR DESCRIPTION
背景
- Search Console でサイトを追加する際に Google タグマネージャー(GTM)を使って所有権の確認を行う
- サイト側で `<body>` タグと GTMのスニペットの間に別のタグが挟まれている状態だと確認がエラーになる
- GTMスニペットの位置を `<body>` 直下に移動して対応する
