### PR TITLE
Order by recently for posts API

### DIFF
--- a/app/controllers/api/posts_controller.rb
+++ b/app/controllers/api/posts_controller.rb
@@ -7,7 +7,7 @@ class Api::PostsController < Api::ApplicationController
         current_site.posts
       end
 
-    posts = scope.published.page(params.dig(:page, :number)).per(params.dig(:page, :size))
+    posts = scope.published.order_by_recently.page(params.dig(:page, :number)).per(params.dig(:page, :size))
     render json: posts, include: "category"
   end
 


### PR DESCRIPTION
For `/press`, `/press/category/:slug` and `/press/feed`.
