### PR TITLE
Include category to fix N+1 problem for search result set

### DIFF
--- a/app/groonga/post_search_result_set.rb
+++ b/app/groonga/post_search_result_set.rb
@@ -16,7 +16,7 @@ class PostSearchResultSet
   end
 
   def posts
-    @posts ||= @site.posts.includes(credits: [:participant]).published.where(id: searched_post_ids).order_by_recently.page(@page).per(50)
+    @posts ||= @site.posts.includes(:category, credits: [:participant]).published.where(id: searched_post_ids).order_by_recently.page(@page).per(50)
   end
 
   def snippet(text, html_options = {})


### PR DESCRIPTION
The following queries are run:

```
Category Load (0.1ms)  SELECT  "categories".* FROM "categories" WHERE "categories"."id" = $1 LIMIT 1  [
["id", 2]]
  Rendered posts/_summary.html.haml (11.7ms)
  Category Load (0.1ms)  SELECT  "categories".* FROM "categories" WHERE "categories"."id" = $1 LIMIT 1  [
["id", 1]]
  Rendered posts/_summary.html.haml (3.9ms)
  CACHE (0.0ms)  SELECT  "categories".* FROM "categories" WHERE "categories"."id" = $1 LIMIT 1  [["id", 1
]]
  Rendered posts/_summary.html.haml (2.9ms)
  CACHE (0.0ms)  SELECT  "categories".* FROM "categories" WHERE "categories"."id" = $1 LIMIT 1  [["id", 1
]]
  Rendered posts/_summary.html.haml (3.1ms)
  CACHE (0.0ms)  SELECT  "categories".* FROM "categories" WHERE "categories"."id" = $1 LIMIT 1  [["id", 1
]]
  Rendered posts/_summary.html.haml (2.7ms)
  CACHE (0.0ms)  SELECT  "categories".* FROM "categories" WHERE "categories"."id" = $1 LIMIT 1  [["id", 1
]]
  Rendered posts/_summary.html.haml (2.5ms)
  CACHE (0.0ms)  SELECT  "categories".* FROM "categories" WHERE "categories"."id" = $1 LIMIT 1  [["id", 1
]]
  Rendered posts/_summary.html.haml (2.4ms)
  CACHE (0.0ms)  SELECT  "categories".* FROM "categories" WHERE "categories"."id" = $1 LIMIT 1  [["id", 1
]]
  Rendered posts/_summary.html.haml (2.5ms)
...
```
