### PR TITLE
rubocop: Disable checks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -58,3 +58,7 @@ Style/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
 Style/BlockDelimiters:
   EnforcedStyle: braces_for_chaining
+Style/ClassAndModuleChildren:
+  Enabled: false
+Style/EmptyCaseCondition:
+  Enabled: false


### PR DESCRIPTION
- Style/ClassAndModuleChildren
  - We know difference between nested style and compact style
- Style/EmptyCaseCondition
  - I prefer empty case condition than if-elsif style
