### PR TITLE
Fix post edit form

### DIFF
--- a/app/views/editor/posts/_form.html.haml
+++ b/app/views/editor/posts/_form.html.haml
@@ -1,4 +1,4 @@
-= bootstrap_form_for [:editor, @post], layout: :horizontal, label_col: 'col-sm-2', control_col: 'col-sm-10' do |f|
+= bootstrap_form_for [:editor, @post], url: editor_post_url(@post.public_id), layout: :horizontal, label_col: 'col-sm-2', control_col: 'col-sm-10' do |f|
   = f.text_field :title
   = f.text_area :body, class: "markdown-editor", data: {upload_path: editor_images_url}
   - if current_site.credit_enabled?

--- a/test/integration/post_public_id_test.rb
+++ b/test/integration/post_public_id_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+class PostPublicIdTest < ActionDispatch::IntegrationTest
+  setup do
+    site = create(:site, fqdn: "127.0.0.1")
+    user = create(:user, sites: [site])
+    login_as_editor(site: site, editor: user)
+
+    @post = create(:post, site: site, category: create(:category, site: site))
+    @post.update!(public_id: @post.id + 1)
+  end
+
+  test "Can update a post which has id != public_id" do
+    # TODO: We should navigate by click
+    visit "/editor/posts/#{@post.public_id}/edit"
+
+    fill_in "Title", with: "Ruby x.x.x Released"
+
+    click_on "更新する"
+
+    visit "/#{@post.public_id}"
+
+    within ".post__title" do
+      assert_equal "Ruby x.x.x Released", page.text
+    end
+  end
+end


### PR DESCRIPTION
If we remove `to_param`, we must specify the form's url :see_no_evil: 

ref: https://github.com/bm-sms/daimon-news/pull/539
