### PR TITLE
Increase `MetaTags.title_limit` to unlimited

### DIFF
--- a/config/initializers/meta_tags.rb
+++ b/config/initializers/meta_tags.rb
@@ -1,0 +1,3 @@
+MetaTags.configure do |c|
+  c.title_limit = nil
+end


### PR DESCRIPTION
Default value is 70, this is too short for us.

connect to https://github.com/bm-sms/daimon-news-misc/issues/146
