### PR TITLE
Fix to use `Post#public_id` for sitemap.xml

### DIFF
--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -18,7 +18,7 @@ end
 
 SitemapGenerator::Sitemap.create do
   site.posts.published.find_each do |post|
-    add post_path(post), changefreq: "weekly", priority: 0.8
+    add post_path(post.public_id), changefreq: "weekly", priority: 0.8
   end
 
   site.categories.find_each do |category|


### PR DESCRIPTION
This is a part of this change https://github.com/bm-sms/daimon-news/pull/550.

Fix https://github.com/bm-sms/nursepress/issues/299.
