### PR TITLE
Adjust posts order

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -23,7 +23,7 @@ class Post < ActiveRecord::Base
   before_save :assign_public_id
 
   scope :published, -> { where("published_at <= ?", Time.current) }
-  scope :order_by_recent, -> { order(published_at: :desc, id: :asc) }
+  scope :order_by_recent, -> { order(["published_at DESC NULLS LAST", id: :asc]) }
   scope :categorized_by, lambda {|category|
     category_ids = category.has_children? ? category.subtree_ids : [category.id]
     joins(:categories).where("categories.id" => category_ids).uniq

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -11,6 +11,19 @@ class PostTest < ActiveSupport::TestCase
     I18n.locale = @default_locale
   end
 
+  sub_test_case "order_by_recent" do
+    setup do
+      category = create(:category, site: @site)
+      create(:post, title: "older", published_at: "20160630", site: @site, categorizations_attributes: [{category: category, order: 1}])
+      create(:post, title: "NULL",  published_at: nil,        site: @site, categorizations_attributes: [{category: category, order: 1}])
+      create(:post, title: "newer", published_at: "20160701", site: @site, categorizations_attributes: [{category: category, order: 1}])
+    end
+
+    def test_null_should_not_recent
+      assert_equal Post.order_by_recent.pluck(:title), ["newer", "older", "NULL"]
+    end
+  end
+
   sub_test_case "relation" do
     setup do
       category = create(:category, site: @site)


### PR DESCRIPTION
When `Post#published_at` is `nil`, it shouldn't be a recent post.

ref https://github.com/bm-sms/nursepress/issues/315
