### PR TITLE
Reduce query by removing `children_or_posts?`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ group :development, :test do
 end
 
 group :development do
+  gem "active_record_query_trace"
   gem "bullet"
   gem "launchy"
   gem "pry-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,7 @@ GEM
       activemodel (>= 4.1, < 6)
       jsonapi (~> 0.1.1.beta2)
       railties (>= 4.1, < 6)
+    active_record_query_trace (1.5.3)
     activejob (4.2.7.1)
       activesupport (= 4.2.7.1)
       globalid (>= 0.3.0)
@@ -519,6 +520,7 @@ DEPENDENCIES
   active_decorator
   active_link_to
   active_model_serializers
+  active_record_query_trace
   airbrake
   ancestry
   bootstrap-sass

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -62,10 +62,6 @@ class Category < ActiveRecord::Base
     end
   end
 
-  def children_or_posts?
-    children? || posts.published.count.nonzero?
-  end
-
   def higher_item
     siblings.where('"order" < ?', order).ordered.last
   end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -31,6 +31,11 @@ class Site < ActiveRecord::Base
     public_participant_page_enabled? && participants.having_published_posts.exists?
   end
 
+  def posted_root_categories
+    ids = categories.select(:id, :ancestry).joins(:categorizations).uniq.map {|c| c.root_id || c.id }.uniq
+    categories.where(id: ids)
+  end
+
   private
 
   def validate_category_title_format

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -21,7 +21,7 @@
           %p.menu__item.menu__item--press.menu__section.yyy{data: {menu_item_state: current_category.nil? ? 'current' : nil}}
             = link_to 'Press', root_url, class: 'menu__label'
 
-          = render partial: 'application/categories', locals: {categories: current_site.categories.roots.ordered.select(&:children_or_posts?), current_category: current_category}
+          = render partial: 'application/categories', locals: {categories: current_site.posted_root_categories.ordered, current_category: current_category}
 
       = content_for(:welcome_content)
 
@@ -63,7 +63,7 @@
 
             %h2.subheading.subheading--aside カテゴリ
             %ul.category-list
-              - current_site.categories.roots.ordered.select(&:children_or_posts?).each do |category|
+              - current_site.posted_root_categories.ordered.each do |category|
                 %li.category-list__item
                   = link_to category.name, category_url(category.slug)
           - if current_site.promotion_url.present?

--- a/config/initializers/active_record_query_trace.rb
+++ b/config/initializers/active_record_query_trace.rb
@@ -1,0 +1,1 @@
+ActiveRecordQueryTrace.enabled = true if defined?(ActiveRecordQueryTrace)

--- a/db/seeds/development/categories.seeds.rb
+++ b/db/seeds/development/categories.seeds.rb
@@ -1,25 +1,17 @@
 after "development:sites" do
   site1 = Site.find_by!(name: "site1")
 
-  site1.categories.create!(
-    name:        "category 1",
-    description: "category 1",
-    slug:        "category1",
-    order:       1
-  )
-  site1.categories.create!(
-    name:        "category 2",
-    description: "category 2",
-    slug:        "category2",
-    order:       2
-  )
+  (1..100).each do |n|
+    site1.categories.create!(
+      name:        "category #{n}",
+      description: "category #{n}",
+      slug:        "category#{n}",
+      order:       n
+    )
+  end
 
-  category3 = site1.categories.create!(
-    name:        "category 3",
-    description: "category 3",
-    slug:        "category3",
-    order:       3
-  )
+  category3 = site1.categories.find_by!(slug: "category3")
+
   category3_1 = category3.children.create!(
     name:        "category 3-1",
     description: "category 3-1",

--- a/test/factories/category.rb
+++ b/test/factories/category.rb
@@ -1,5 +1,9 @@
 FactoryGirl.define do
   factory :category do
+    transient do
+      categories []
+    end
+
     sequence(:name) {|n| "Category #{n}" }
     sequence(:slug) {|n| "category#{n}" }
     description { "#{name} description\n" }

--- a/test/factories/post.rb
+++ b/test/factories/post.rb
@@ -5,13 +5,22 @@ FactoryGirl.define do
     thumbnail { Rails.root.join("test/fixtures/images/thumbnail.jpg").open }
     published_at { DateTime.parse("2016-01-01") }
 
+    transient do
+      categories []
+    end
+
+    after :build do |post, evaluator|
+      evaluator.categories.each do |category|
+        post.categorizations.build(attributes_for(:categorization, :whatever, category: category))
+      end
+    end
+
+    after(:create, &:reload) # To refresh `post.categories`
+
     trait :whatever do
       site
       before :create do |post, _evaluator|
         post.categorizations.build(attributes_for(:categorization, :whatever, site: post.site))
-      end
-      after :create do |post, _evaluator|
-        post.reload # To refresh `post.categories`
       end
     end
 

--- a/test/models/site_test.rb
+++ b/test/models/site_test.rb
@@ -136,4 +136,31 @@ class SiteTest < ActiveSupport::TestCase
       assert_not_equal(before_content, after_content)
     end
   end
+
+  sub_test_case "#posted_root_categories" do
+    setup do
+      @site = create(:site)
+      @root_category_with_grandchild = create(:category, site: @site)
+      @root_category_without_child = create(:category, site: @site)
+      @grandchild_category = create(:category, site: @site, parent: create(:category, site: @site, parent: @root_category_with_grandchild))
+
+      create(:post, :whatever) # create another site has a category and a post
+    end
+
+    test "when the site has no posted categories" do
+      assert_equal([], @site.posted_root_categories.pluck(:id))
+    end
+
+    test "when the site has a posted category which doesn't have any child" do
+      create(:post, site: @site, categories: [@root_category_without_child])
+
+      assert_equal([@root_category_without_child.id], @site.posted_root_categories.pluck(:id))
+    end
+
+    test "when the site has a root category which has posted grandchild" do
+      create(:post, site: @site, categories: [@grandchild_category])
+
+      assert_equal([@root_category_with_grandchild.id], @site.posted_root_categories.pluck(:id))
+    end
+  end
 end


### PR DESCRIPTION
Following code invokes many SQL.

`current_site.categories.roots.ordered.select(&:children_or_posts?)`

`children_or_posts?` invokes one or two query and certain site has 50 root categories
so it invokes about 50 ~ 100 query :exclamation:
