### PR TITLE
Use `ActiveRecord::Relation#exists?` instead of `present?`

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -51,7 +51,7 @@
                 - current_site.posts.includes(:categories).published.order_by_recent.limit(5).each do |post|
                   = render partial: 'posts/summary_with_content', locals: {post: post}
 
-            - if current_site.serials.present?
+            - if current_site.serials.exists?
               %h2.subheading.subheading--aside.subheading--press-articles 連載
               %p.to-serials
                 = link_to 'すべての連載を見る', serials_url


### PR DESCRIPTION
To prevent loading unnecessary records:
- `ActiveRecord::Relation#exists?`
  
  > SELECT  1 AS one FROM "serials" WHERE "serials"."site_id" = $1 LIMIT 1  [["site_id", 1]]
- `ActiveRecord::Relation#present?`
  
  > SELECT "serials".\* FROM "serials" WHERE "serials"."site_id" = $1 [["site_id", 1]]
