### PR TITLE
Updates to display category#description as meta-description of header.

### DIFF
--- a/app/decorators/category_decorator.rb
+++ b/app/decorators/category_decorator.rb
@@ -4,7 +4,7 @@ module CategoryDecorator
       locale: "ja_JP",
       type: "object",
       title: [name, site.tagline, site.name].select(&:present?).join(" | "),
-      description: MetaTags::TextNormalizer.normalize_description(render_markdown(description)),
+      description: meta_description,
       url: category_url(slug: slug),
       site_name: site.name,
       image: site.logo_image_url
@@ -36,5 +36,9 @@ module CategoryDecorator
     return false unless other
 
     super
+  end
+
+  def meta_description
+    MetaTags::TextNormalizer.normalize_description(render_markdown(description)).presence || current_site.tagline
   end
 end

--- a/app/views/categories/show.html.haml
+++ b/app/views/categories/show.html.haml
@@ -14,6 +14,7 @@
   - breadcrumb :category, @category
 - set_meta_tags title: page_title, og: @category.to_og_params
 - set_meta_tags og: {url: canonical_url, title: "#{page_title} | #{current_site.name}"}
+- set_meta_tags description: @category.meta_description
 
 %section
   %h1.category-header= @category.name

--- a/test/integration/current_category_test.rb
+++ b/test/integration/current_category_test.rb
@@ -53,4 +53,23 @@ class CurrentCategoryTest < ActionDispatch::IntegrationTest
 
     assert_equal("https://www.ruby-lang.org/", find(".category-description a")[:href])
   end
+
+  test "render meta description" do
+    visit("/category/ruby")
+    assert_equal("Ruby is a programming language.", find("meta[name=description]", visible: false)["content"])
+  end
+
+  sub_test_case "render meta description (in case category description is blank)" do
+    setup do
+      @site.tagline = 'This is awesome sites!'
+      @site.save!
+      @category = create(:category, site: @site, name: "Python", slug: "python", description: '')
+      @post = create(:post, :with_pages, site: @site, categorizations_attributes: [{category: @category, order: 1}])
+    end
+
+    test "test execution" do
+      visit("/category/python")
+      assert_equal(@site.tagline, find("meta[name=description]", visible: false)["content"])
+    end
+  end
 end


### PR DESCRIPTION
Resolve #638
Updates to display the attribute of category#description as meta-description of header when access to `/category/:slug`.
