### PR TITLE
Run Groonga database initialization in background

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec ruby groonga/init.rb && bundle exec puma -C config/puma.rb
+web: (bundle exec ruby groonga/init.rb &) && bundle exec puma -C config/puma.rb


### PR DESCRIPTION
カテゴリデータが大量に投入されると、Heroku のアプリケーション起動の 60 秒制限にひっかかってしまうようになります。
取り込みスクリプトの最適化にも限度がありそうなので、そろそろ別の方法を模索してもよいころかなと思いました。

ひとまずバックエンドで実行してみるのを試みたんですが、どうですかね…？
