### PR TITLE
Use Redis as cache store

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,4 +77,5 @@ group :production do
   gem "rack-cors"
   gem "rack-timeout"
   gem "rails_12factor"
+  gem "redis-rails"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -414,6 +414,23 @@ GEM
       nokogiri (>= 1.4.1)
       trollop
     redcarpet (3.3.4)
+    redis (3.3.1)
+    redis-actionpack (4.0.1)
+      actionpack (~> 4)
+      redis-rack (~> 1.5.0)
+      redis-store (~> 1.1.0)
+    redis-activesupport (4.1.5)
+      activesupport (>= 3, < 5)
+      redis-store (~> 1.1.0)
+    redis-rack (1.5.0)
+      rack (~> 1.5)
+      redis-store (~> 1.1.0)
+    redis-rails (4.0.0)
+      redis-actionpack (~> 4)
+      redis-activesupport (~> 4)
+      redis-store (~> 1.1.0)
+    redis-store (1.1.7)
+      redis (>= 2.2)
     responders (2.3.0)
       railties (>= 4.2.0, < 5.1)
     rouge (2.0.6)
@@ -556,6 +573,7 @@ DEPENDENCIES
   rails_12factor
   rambulance
   redcarpet
+  redis-rails
   rouge
   rroonga
   rubocop
@@ -573,4 +591,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.12.5
+   1.13.4

--- a/app.json
+++ b/app.json
@@ -43,10 +43,11 @@
     }
   },
   "addons": [
+    "airbrake:free-hrku",
     "heroku-postgresql:hobby-dev",
-    "papertrail:choklad",
+    "heroku-redis:hobby-dev",
     "newrelic:wayne",
-    "airbrake:free-hrku"
+    "papertrail:choklad"
   ],
   "buildpacks": [
     {

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,8 +1,10 @@
 module MarkdownHelper
   def render_markdown(markdown_text)
-    processor = DaimonMarkdown::Processor.new
-    result = processor.call(markdown_text)
-    result[:output].to_html.html_safe
+    Rails.cache.fetch([:post, :markdown_body, Digest::MD5.hexdigest(markdown_text)]) do
+      processor = DaimonMarkdown::Processor.new
+      result = processor.call(markdown_text)
+      result[:output].to_html.html_safe
+    end
   end
 
   def extract_plain_text(markdown_text)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -56,6 +56,7 @@ Rails.application.configure do
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
+  config.cache_store = :redis_store, ENV["REDIS_URL"]
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   config.action_controller.asset_host = ENV["ASSET_HOST"] if !ENV["DISABLE_ACTION_CONTROLLER_ASSET_HOST"] && ENV["ASSET_HOST"]


### PR DESCRIPTION
Markdown rendering is too slow and it causes boot timeout on Heroku.
To improve performance, we can introduce Redis as cache store.
