### PR TITLE
add heroku-deflater

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,7 @@ end
 
 group :production do
   gem "airbrake"
+  gem "heroku-deflater"
   gem "newrelic_rpm"
   gem "rack-contrib", require: "rack/contrib"
   gem "rack-cors"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -280,6 +280,8 @@ GEM
       html2haml (>= 1.0.1)
       railties (>= 4.0.1)
     hashie (3.4.6)
+    heroku-deflater (0.6.2)
+      rack (>= 1.4.5)
     html-pipeline (2.4.2)
       activesupport (>= 2)
       nokogiri (>= 1.4)
@@ -560,6 +562,7 @@ DEPENDENCIES
   font-awesome-sass
   gretel
   haml-rails
+  heroku-deflater
   kaminari
   launchy
   meta-tags


### PR DESCRIPTION
A simple rack middleware that enables compressing of your assets and application responses on Heroku, while not wasting CPU cycles on pointlessly compressing images and other binary responses. https://github.com/romanbsd/heroku-deflater