### PR TITLE
Override the github git source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,10 @@
 source "https://rubygems.org"
 
+git_source(:github) do |repo_name|
+  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
+  "https://github.com/#{repo_name}.git"
+end
+
 ruby "2.3.3"
 
 gem "rails", "~> 4.2.6"


### PR DESCRIPTION
Override the github git source instead of changing manually all entries

## Before

```
$ bundle install --path vendor/bundle
The git source `git://github.com/mtsmfm/cocoon.git` uses the `git` protocol, which transmits data without encryption. Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.
The git source `git://github.com/bm-sms/daimon_news-layout.git` uses the `git` protocol, which transmits data without encryption. Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.
```

## After
```
$ bundle install --path vendor/bundle
Fetching https://github.com/mtsmfm/cocoon.git
Fetching https://github.com/bm-sms/daimon_news-layout.git
```

### Refs

[Rails way](https://github.com/rails/rails/commit/12d5c21031446686898d5bac924ff3e9e34b6a7d)