### PR TITLE
Override the github git source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,10 @@
 source "https://rubygems.org"
 
+git_source(:github) do |repo_name|
+  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
+  "https://github.com/#{repo_name}.git"
+end
+
 ruby "2.3.3"
 
 gem "rails", "~> 4.2.6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/bm-sms/daimon_news-layout.git
+  remote: https://github.com/bm-sms/daimon_news-layout.git
   revision: b2303364234c2a89eb2ad4cbfccb0163c7aaaa10
   specs:
     daimon_news-layout (0.1.0)
@@ -8,7 +8,7 @@ GIT
       neat
 
 GIT
-  remote: git://github.com/mtsmfm/cocoon.git
+  remote: https://github.com/mtsmfm/cocoon.git
   revision: 4a14bb3ae46a465c0385477eacab48385b9ddb59
   branch: fix-on-ready-for-jquery-3
   specs:


### PR DESCRIPTION
Sorry.
I did `push -f` to commit additional missing Gemfile.lock.
As a result, #675 can't be reopened.

The following is copy from #675.

Override the github git source instead of changing manually all entries

## Before

```
$ bundle install --path vendor/bundle
The git source `git://github.com/mtsmfm/cocoon.git` uses the `git` protocol, which transmits data without encryption. Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.
The git source `git://github.com/bm-sms/daimon_news-layout.git` uses the `git` protocol, which transmits data without encryption. Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.
```

## After
```
$ bundle install --path vendor/bundle
Fetching https://github.com/mtsmfm/cocoon.git
Fetching https://github.com/bm-sms/daimon_news-layout.git
```

### Refs

[Rails way](https://github.com/rails/rails/commit/12d5c21031446686898d5bac924ff3e9e34b6a7d)