### PR TITLE
Check the assosiated objects destruction

### DIFF
--- a/test/factories/fixed_page.rb
+++ b/test/factories/fixed_page.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :fixed_page do
+    sequence(:title) {|n| "Page #{n}" }
+    body { "#{title} body\n" }
+    sequence(:slug) {|n| "page#{n}" }
+  end
+end

--- a/test/factories/link.rb
+++ b/test/factories/link.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :link do
+    sequence(:text) {|i| "Url #{i}" }
+    sequence(:url) {|i| "/url#{i}" }
+    sequence(:order)
+  end
+end

--- a/test/factories/membership.rb
+++ b/test/factories/membership.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :membership do
+    site
+    user
+  end
+end

--- a/test/factories/popular_post.rb
+++ b/test/factories/popular_post.rb
@@ -1,0 +1,10 @@
+FactoryGirl.define do
+  factory :popular_post do
+    trait :whatever do
+      site
+      sequence(:rank)
+
+      post { create(:post, :whatever, site: site) }
+    end
+  end
+end

--- a/test/models/site_test.rb
+++ b/test/models/site_test.rb
@@ -13,22 +13,58 @@ class SiteTest < ActiveSupport::TestCase
   sub_test_case "relation" do
     setup do
       @site = create(:site)
-      @post = create(:post, :whatever, site: @site)
+      @post = create(:post, :whatever, :with_credit, site: @site)
       Tempfile.open do |file|
         @site.images.create!(image: file)
       end
+      create(:serial, site: @site)
+
+      create(:fixed_page, site: @site)
+      create(:link,       site: @site)
+      create(:membership, site: @site)
+      @site.redirect_rules.create!(request_path: "/foo", destination: "/bar")
+
+      create(:pickup_post,    :whatever, post: @post, site: @site)
+      create(:popular_post,   :whatever, post: @post, site: @site)
+      create(:top_fixed_post, :whatever, post: @post, site: @site)
     end
 
     test "destroy site" do
       assert_equal(1, Site.count)
-      assert_equal(1, Category.count)
       assert_equal(1, Post.count)
       assert_equal(1, Image.count)
+      assert_equal(1, Serial.count)
+      assert_equal(1, Category.count)
+      assert_equal(1, CreditRole.count)
+      assert_equal(1, Participant.count)
+
+      assert_equal(1, FixedPage.count)
+      assert_equal(1, Link.count)
+      assert_equal(1, Membership.count)
+      assert_equal(1, RedirectRule.count)
+
+      assert_equal(1, PickupPost.count)
+      assert_equal(1, PopularPost.count)
+      assert_equal(1, TopFixedPost.count)
+
       @site.destroy
+
       assert_equal(0, Site.count)
-      assert_equal(0, Category.count)
       assert_equal(0, Post.count)
       assert_equal(0, Image.count)
+      assert_equal(0, Serial.count)
+      assert_equal(0, Category.count)
+      assert_equal(0, CreditRole.count)
+      assert_equal(0, Participant.count)
+
+      assert_equal(0, FixedPage.count)
+      assert_equal(0, Link.count)
+      assert_equal(0, Membership.count)
+      assert_equal(0, RedirectRule.count)
+
+      assert_equal(0, PickupPost.count)
+      assert_equal(0, PopularPost.count)
+      assert_equal(0, TopFixedPost.count)
     end
   end
 

--- a/test/models/site_test.rb
+++ b/test/models/site_test.rb
@@ -22,7 +22,7 @@ class SiteTest < ActiveSupport::TestCase
       create(:fixed_page, site: @site)
       create(:link,       site: @site)
       create(:membership, site: @site)
-      @site.redirect_rules.create!(request_path: "/foo", destination: "/bar")
+      create(:redirect_rule, :whatever, site: @site)
 
       create(:pickup_post,    :whatever, post: @post, site: @site)
       create(:popular_post,   :whatever, post: @post, site: @site)
@@ -47,6 +47,7 @@ class SiteTest < ActiveSupport::TestCase
       assert_equal(1, PopularPost.count)
       assert_equal(1, TopFixedPost.count)
 
+      @site.reload
       @site.destroy
 
       assert_equal(0, Site.count)


### PR DESCRIPTION
I think `dependent: :destroy` on the site model works fine. Added some assertions for checking the associated objects destruction.